### PR TITLE
fix bugs in data loader

### DIFF
--- a/nnfabrik/datasets/__init__.py
+++ b/nnfabrik/datasets/__init__.py
@@ -1,2 +1,3 @@
 from . import csrf_v1_dataset
+from .csrf_v1_dataset import csrf_v1
 from .toy_datasets import toy_dataset

--- a/nnfabrik/models/__init__.py
+++ b/nnfabrik/models/__init__.py
@@ -1,2 +1,2 @@
-from . import v1_models
+from .v1_models import stacked2d_core_point_readout
 from .toy_models import toy_model

--- a/nnfabrik/training/__init__.py
+++ b/nnfabrik/training/__init__.py
@@ -1,2 +1,3 @@
 from . import trainers
+from .trainers import early_stop_trainer
 from .toy_trainers import toy_trainer

--- a/nnfabrik/utility/nnf_helper.py
+++ b/nnfabrik/utility/nnf_helper.py
@@ -1,5 +1,21 @@
 from importlib import import_module
+import numpy as np
 
+def cleanup_numpy_scalar(data):
+    """
+    Recursively cleanups up a (potentially nested data structure of) 
+    objects, replacing any scalar numpy instance with the corresponding
+    Python native datatype.
+    """
+    if isinstance(data, np.generic):
+        if data.shape == ():
+            data = data.item()
+    elif isinstance(data, dict):
+        for k, v in data.items():
+            data[k] = cleanup_numpy_scalar(v)
+    elif isinstance(data, (list, tuple)):
+        data = [cleanup_numpy_scalar(e) for e in data]
+    return data
 
 def split_module_name(abs_class_name):
     abs_module_path = '.'.join(abs_class_name.split('.')[:-1])


### PR DESCRIPTION
* import loader function name explicitly in the subpackage `__init__.py`
* implement clean up utility function to convert dictionary of scalars with NumPy scalars, turning them into native Python types
* make `schema_name` in `dj.config` optional, defaulting to `nnfabrik_core`