### PR TITLE
Changed MINIO Endpoint to be read from environment

### DIFF
--- a/nnfabrik/main.py
+++ b/nnfabrik/main.py
@@ -13,7 +13,7 @@ from .utility.nnf_helper import split_module_name, dynamic_import, cleanup_numpy
 dj.config['stores'] = {
     'minio': {    #  store in s3
         'protocol': 's3',
-        'endpoint': os.environ.get('MINIO_ENDPOINT'),
+        'endpoint': os.environ.get('MINIO_ENDPOINT', 'DUMMY_ENDPOINT'),
         'bucket': 'nnfabrik',
         'location': 'dj-store',
         'access_key': os.environ.get('MINIO_ACCESS_KEY', 'FAKEKEY'),


### PR DESCRIPTION
This way we are no longer hard-coding the MINIO Endpoint in the code and make it more flexible. 