### PR TITLE
Allow skip duplicate in add_entry and return resulting entry key

### DIFF
--- a/nnfabrik/main.py
+++ b/nnfabrik/main.py
@@ -90,7 +90,17 @@ class Model(dj.Manual):
         model_hash = make_hash(model_config)
         key = dict(model_fn=model_fn, model_hash=model_hash, model_config=model_config,
                    model_fabrikant=model_fabrikant, model_comment=model_comment)
-        self.insert1(key, skip_duplicates=skip_duplicates)
+
+        existing = self.proj() & key
+        if existing:
+            if skip_duplicates:
+                warnings.warn('Corresponding entry found. Skipping...')
+                key = (self & (existing)).fetch1()
+            else:
+                raise ValueError('Corresponding entry already exists')
+        else:
+            self.insert1(key)
+        
         return key
 
     def build_model(self, dataloaders, seed=None, key=None):
@@ -149,7 +159,17 @@ class Dataset(dj.Manual):
         dataset_hash = make_hash(dataset_config)
         key = dict(dataset_fn=dataset_fn, dataset_hash=dataset_hash,
                    dataset_config=dataset_config, dataset_fabrikant=dataset_fabrikant, dataset_comment=dataset_comment)
-        self.insert1(key, skip_duplicates=skip_duplicates)
+        
+        existing = self.proj() & key
+        if existing:
+            if skip_duplicates:
+                warnings.warn('Corresponding entry found. Skipping...')
+                key = (self & (existing)).fetch1()
+            else:
+                raise ValueError('Corresponding entry already exists')
+        else:
+            self.insert1(key)
+        
         return key
 
     def get_dataloader(self, seed=None, key=None):
@@ -227,7 +247,17 @@ class Trainer(dj.Manual):
         key = dict(trainer_fn=trainer_fn, trainer_hash=trainer_hash,
                    trainer_config=trainer_config, trainer_fabrikant=trainer_fabrikant,
                    trainer_comment=trainer_comment)
-        self.insert1(key, skip_duplicates=skip_duplicates)
+
+        existing = self.proj() & key
+        if existing:
+            if skip_duplicates:
+                warnings.warn('Corresponding entry found. Skipping...')
+                key = (self & (existing)).fetch1()
+            else:
+                raise ValueError('Corresponding entry already exists')
+        else:
+            self.insert1(key)
+        
         return key
 
     def get_trainer(self, key=None, build_partial=True):


### PR DESCRIPTION
* Make `add_entry` take argument `skip_duplicates` so that one can make an entry and have it ignored without an error if the corresponding entry already exists.
* In combination with the above behavior, `add_entry` now returns the resulting (or existing) entry key.

Together, this simplifies any logic for ensuring that a desired fn + config entry already exists in the target table. Furthermore, this lets the end-user avoid the potentially error-prone check of the hash of the config external to the function. 