### PR TITLE
Add cached dataloader for monkey csrf data

### DIFF
--- a/nnfabrik/datasets/sysident_v1_dataset.py
+++ b/nnfabrik/datasets/sysident_v1_dataset.py
@@ -247,7 +247,7 @@ def monkey_static_loader(dataset,
         train_loader = get_cached_loader(training_image_ids, responses_train, batch_size=batch_size, image_cache=cache)
         val_loader = get_cached_loader(validation_image_ids, responses_val, batch_size=batch_size, image_cache=cache)
         test_loader = get_cached_loader(testing_image_ids, responses_test, batch_size=1, shuffle=False,
-                                                image_cache=cache, repeats=testing_image_ids)
+                                                image_cache=cache, repeat_condition=testing_image_ids)
 
         dataloaders["train"][data_key] = train_loader
         dataloaders["validation"][data_key] = val_loader


### PR DESCRIPTION
Adds a new dataloader function that makes use of an image cache. The dataloader will no longer load all images into memory, but will do so flexibly when returning batches. This requires the user to have all images saved individually on disk as numpy arrays.
The previous functions remain untouched to allow for backwards compatibility.