### PR TITLE
Speed up model Initialization

### DIFF
--- a/nnfabrik/utility/nn_helpers.py
+++ b/nnfabrik/utility/nn_helpers.py
@@ -48,9 +48,10 @@ def get_module_output(model, input_shape):
     device = 'cuda' if torch.cuda.is_available() else 'cpu'
     with eval_state(model):
         with torch.no_grad():
-            tensor_out = model.to(device)(torch.zeros(input_shape).to(device)).shape
+            input = torch.zeros(1, *input_shape[1:]).to(device)
+            output = model.to(device)(input)
     model.to(initial_device)
-    return tensor_out
+    return output.shape
 
 def set_random_seed(seed):
     """


### PR DESCRIPTION
So far, model initialization pushed one training batch from all dataloaders through the core. For large images, this can take a while, because the model will always be on the CPU. This PR will reduce the batch size of the input tensor to one, and sets the model to cuda if avilable, and sets it back to the initial device.