### PR TITLE
Add `my_nnfabrik` to facilitate creation and use of project specific nnfabrik tables

### DIFF
--- a/nnfabrik/main.py
+++ b/nnfabrik/main.py
@@ -356,6 +356,7 @@ class Seed(dj.Manual):
 def custom_nnfabrik(
     schema,
     use_common_fabrikant=True,
+    use_common_seed=False,
     module_name=None,
     context=None,
     spawn_existing_tables=False,
@@ -371,6 +372,9 @@ def custom_nnfabrik(
         use_common_fabrikant (bool, optional): If True, new tables will depend on the
            common Fabrikant table. If False, new copy of Fabrikant will be created and used. 
            Defaults to True.
+        use_common_seed (bool, optional): If True, new tables will depend on the
+           common Seed table. If False, new copy of Seed will be created and used. 
+           Defaults to False.
         module_name (str, optional): Name property of the returned Python module object.
             Defaults to None, in which case the name of the schema will be used.
         context (dict, optional): If non None value is provided, then a module is not created and
@@ -387,6 +391,9 @@ def custom_nnfabrik(
         schema = CustomSchema(schema)
 
     tables = [Fabrikant, Model, Dataset, Trainer]
+
+    if not use_common_seed:
+        tables.append(Seed)
 
     module = None
     if context is None:
@@ -409,7 +416,7 @@ def custom_nnfabrik(
         else:
             context["Fabrikant"] = Fabrikant
             # skip creating Fabrikant table
-            tables.pop(0)
+            tables.remove(Fabrikant)
 
     for table in tables:
         new_table = type(table.__name__, (table,), dict(__doc__=table.__doc__))

--- a/nnfabrik/main.py
+++ b/nnfabrik/main.py
@@ -1,5 +1,5 @@
-import os
 import warnings
+import types
 
 import datajoint as dj
 
@@ -351,3 +351,61 @@ class Seed(dj.Manual):
     definition = """
     seed:   int     # Random seed that is passed to the model- and dataset-builder
     """
+
+
+def custom_nnfabrik(
+    schema, use_common_fabrikant=True, module_name=None, spawn_existing_tables=False
+):
+    """
+    Create a custom nnfabrik module under specified DataJoint schema,
+    instantitaing Model, Dataset, and Trainer tables. If `use_common_fabrikant`
+    is set to True, the new tables will depend on the common Fabrikant table. 
+    Otherwise, a separate copy of Fabrikant table will also be prepared.
+
+    Args:
+        schema (str or dj.Schema): Name of schema or dj.Schema object
+        use_common_fabrikant (bool, optional): If True, new tables will depend on the
+           common Fabrikant table. If False, new copy of Fabrikant will be created and used. 
+           Defaults to True.
+        module_name (str, optional): Name property of the returned Python module object.
+            Defaults to None, in which case the name of the schema will be used.
+        spawn_existing_tables (bool, optional): If True, perform `spawn_missing_tables` operation
+            onto the newly created table. Defaults to False.
+
+    Returns:
+        Python Module object: A new Python module containing nnfabrik tables defined under
+            the schema. The module's schema property points to the schema object as well.
+    """
+    if isinstance(schema, str):
+        schema = CustomSchema(schema)
+
+    tables = [Fabrikant, Model, Dataset, Trainer]
+
+    module_name = schema.database if module_name is None else module_name
+    module = types.ModuleType(module_name)
+    setattr(module, "schema", schema)
+
+    # spawn all existing tables into the module
+    # TODO: replace with a cheaper check operation
+    if spawn_existing_tables:
+        context = module.__dict__
+    else:
+        context = {}
+
+    schema.spawn_missing_classes(context)
+
+    if use_common_fabrikant:
+        if "Fabrikant" in context:
+            warnings.warn(
+                "The schema already contained Fabrikant table. Using that table instead of the common one!"
+            )
+        else:
+            setattr(module, "Fabrikant", Fabrikant)
+            # skip creating Fabrikant table
+            tables.pop(0)
+
+    for table in tables:
+        new_table = type(table.__name__, (table,), dict(__doc__=table.__doc__))
+        setattr(module, table.__name__, schema(new_table, context=module.__dict__))
+
+    return module

--- a/nnfabrik/main.py
+++ b/nnfabrik/main.py
@@ -444,6 +444,6 @@ def custom_nnfabrik(
         new_table = type(table.__name__, (table,), dict(__doc__=table.__doc__))
         context[table.__name__] = schema(new_table, context=context)
 
-    # this return None if context was set
+    # this returns None if context was set
     return module
 

--- a/nnfabrik/main.py
+++ b/nnfabrik/main.py
@@ -357,12 +357,12 @@ class Seed(dj.Manual):
 
 def my_nnfabrik(
     schema: Union[str, CustomSchema],
-    use_common_fabrikant: bool=True,
-    use_common_seed: bool=False,
-    module_name: Optional[str]=None,
-    context: Optional[MutableMapping]=None,
-    spawn_existing_tables: bool=False,
-) -> Optional[type.ModuleType]:
+    use_common_fabrikant: bool = True,
+    use_common_seed: bool = False,
+    module_name: Optional[str] = None,
+    context: Optional[MutableMapping] = None,
+    spawn_existing_tables: bool = False,
+) -> Optional[types.ModuleType]:
     """
     Create a custom nnfabrik module under specified DataJoint schema,
     instantitaing Model, Dataset, and Trainer tables. If `use_common_fabrikant`
@@ -406,7 +406,8 @@ def my_nnfabrik(
 
     Raises:
         ValueError: If `use_common_fabrikant` is True but the target `schema` already contains its own
-            copy of `Fabrikant` table.
+            copy of `Fabrikant` table, or if `use_common_seed` is True but the target `schema` already
+            contains its own copy of `Seed` table.
 
     Returns:
         Python Module object or None: If `context` was None, a new Python module containing 
@@ -416,10 +417,7 @@ def my_nnfabrik(
     if isinstance(schema, str):
         schema = CustomSchema(schema)
 
-    tables = [Fabrikant, Model, Dataset, Trainer]
-
-    if not use_common_seed:
-        tables.append(Seed)
+    tables = [Seed, Fabrikant, Model, Dataset, Trainer]
 
     module = None
     if context is None:
@@ -436,12 +434,23 @@ def my_nnfabrik(
 
     if use_common_fabrikant:
         if "Fabrikant" in temp_context:
-            raise ValueError("The schema already contains a Fabrikant table despite setting use_common_fabrikant=True. "
-                             "Either rerun with use_common_fabrikant=False or remove the Fabrikant table in the schema")
-        else:
-            context["Fabrikant"] = Fabrikant
-            # skip creating Fabrikant table
-            tables.remove(Fabrikant)
+            raise ValueError(
+                "The schema already contains a Fabrikant table despite setting use_common_fabrikant=True. "
+                "Either rerun with use_common_fabrikant=False or remove the Fabrikant table in the schema"
+            )
+        context["Fabrikant"] = Fabrikant
+        # skip creating Fabrikant table
+        tables.remove(Fabrikant)
+
+    if use_common_seed:
+        if "Seed" in temp_context:
+            raise ValueError(
+                "The schema already contains a Seed table despite setting use_common_seed=True. "
+                "Either rerun with use_common_seed=False or remove the Seed table in the schema"
+            )
+        context["Seed"] = Seed
+        # skip creating Seed table
+        tables.remove(Seed)
 
     for table in tables:
         new_table = type(table.__name__, (table,), dict(__doc__=table.__doc__))

--- a/nnfabrik/main.py
+++ b/nnfabrik/main.py
@@ -1,5 +1,7 @@
 import warnings
 import types
+from typing import Union, Optional, MutableMapping
+
 
 import datajoint as dj
 
@@ -354,13 +356,13 @@ class Seed(dj.Manual):
 
 
 def mein_nnfabrik(
-    schema,
-    use_common_fabrikant=True,
-    use_common_seed=False,
-    module_name=None,
-    context=None,
-    spawn_existing_tables=False,
-):
+    schema: Union[str, CustomSchema],
+    use_common_fabrikant: bool=True,
+    use_common_seed: bool=False,
+    module_name: Optional[str]=None,
+    context: Optional[MutableMapping]=None,
+    spawn_existing_tables: bool=False,
+) -> Optional[type.ModuleType]:
     """
     Create a custom nnfabrik module under specified DataJoint schema,
     instantitaing Model, Dataset, and Trainer tables. If `use_common_fabrikant`
@@ -434,7 +436,8 @@ def mein_nnfabrik(
 
     if use_common_fabrikant:
         if "Fabrikant" in temp_context:
-            raise ValueError("The schema already contains a Fabrikant table despite setting use_common_fabrikant=True. Either rerun with use_common_fabrikant=False or remove the Fabrikant table in the schema")
+            raise ValueError("The schema already contains a Fabrikant table despite setting use_common_fabrikant=True. "
+                             "Either rerun with use_common_fabrikant=False or remove the Fabrikant table in the schema")
         else:
             context["Fabrikant"] = Fabrikant
             # skip creating Fabrikant table

--- a/nnfabrik/main.py
+++ b/nnfabrik/main.py
@@ -355,7 +355,7 @@ class Seed(dj.Manual):
     """
 
 
-def mein_nnfabrik(
+def my_nnfabrik(
     schema: Union[str, CustomSchema],
     use_common_fabrikant: bool=True,
     use_common_seed: bool=False,
@@ -378,16 +378,16 @@ def mein_nnfabrik(
         >>> from nnfabrik import main # importing nnfabrik tables
 
         do this instead:
-        >>> from nnfabrik.main import mein_nnfabrik
-        >>> main = mein_nnfabrik('my_schema')    # this has the same effect as defining nnfabrik tables in schema `my_schema`
+        >>> from nnfabrik.main import my_nnfabrik
+        >>> main = my_nnfabrik('my_schema')    # this has the same effect as defining nnfabrik tables in schema `my_schema`
 
         Also, you can achieve the equivalent of:
         >>> dj.config['nfabrik.schema_name'] = 'my_schema'
         >>> from nnfabrik.main import *
 
         by doing
-        >>> from nnfabrik.main import mein_nnfabrik
-        >>> mein_nnfabrik('my_schema', context=locals())
+        >>> from nnfabrik.main import my_nnfabrik
+        >>> my_nnfabrik('my_schema', context=locals())
 
     Args:
         schema (str or dj.Schema): Name of schema or dj.Schema object

--- a/nnfabrik/main.py
+++ b/nnfabrik/main.py
@@ -354,7 +354,11 @@ class Seed(dj.Manual):
 
 
 def custom_nnfabrik(
-    schema, use_common_fabrikant=True, module_name=None, spawn_existing_tables=False
+    schema,
+    use_common_fabrikant=True,
+    module_name=None,
+    context=None,
+    spawn_existing_tables=False,
 ):
     """
     Create a custom nnfabrik module under specified DataJoint schema,
@@ -369,43 +373,48 @@ def custom_nnfabrik(
            Defaults to True.
         module_name (str, optional): Name property of the returned Python module object.
             Defaults to None, in which case the name of the schema will be used.
+        context (dict, optional): If non None value is provided, then a module is not created and
+            instead the tables are defined inside the context.
         spawn_existing_tables (bool, optional): If True, perform `spawn_missing_tables` operation
             onto the newly created table. Defaults to False.
 
     Returns:
-        Python Module object: A new Python module containing nnfabrik tables defined under
-            the schema. The module's schema property points to the schema object as well.
+        Python Module object or None: If `context` was None, a new Python module containing 
+            nnfabrik tables defined under the schema. The module's schema property points 
+            to the schema object as well. Otherwise, nothing is returned.
     """
     if isinstance(schema, str):
         schema = CustomSchema(schema)
 
     tables = [Fabrikant, Model, Dataset, Trainer]
 
-    module_name = schema.database if module_name is None else module_name
-    module = types.ModuleType(module_name)
-    setattr(module, "schema", schema)
+    module = None
+    if context is None:
+        module_name = schema.database if module_name is None else module_name
+        module = types.ModuleType(module_name)
+        context = module.__dict__
+
+    context["schema"] = schema
 
     # spawn all existing tables into the module
     # TODO: replace with a cheaper check operation
-    if spawn_existing_tables:
-        context = module.__dict__
-    else:
-        context = {}
-
-    schema.spawn_missing_classes(context)
+    temp_context = context if spawn_existing_tables else {}
+    schema.spawn_missing_classes(temp_context)
 
     if use_common_fabrikant:
-        if "Fabrikant" in context:
+        if "Fabrikant" in temp_context:
             warnings.warn(
                 "The schema already contained Fabrikant table. Using that table instead of the common one!"
             )
         else:
-            setattr(module, "Fabrikant", Fabrikant)
+            context["Fabrikant"] = Fabrikant
             # skip creating Fabrikant table
             tables.pop(0)
 
     for table in tables:
         new_table = type(table.__name__, (table,), dict(__doc__=table.__doc__))
-        setattr(module, table.__name__, schema(new_table, context=module.__dict__))
+        context[table.__name__] = schema(new_table, context=context)
 
+    # this return None if context was set
     return module
+

--- a/nnfabrik/main.py
+++ b/nnfabrik/main.py
@@ -4,6 +4,7 @@ from typing import Union, Optional, MutableMapping
 
 
 import datajoint as dj
+from datajoint.schema import Schema
 
 from .builder import (
     resolve_model,
@@ -356,7 +357,7 @@ class Seed(dj.Manual):
 
 
 def my_nnfabrik(
-    schema: Union[str, CustomSchema],
+    schema: Union[str, Schema],
     use_common_fabrikant: bool = True,
     use_common_seed: bool = False,
     module_name: Optional[str] = None,

--- a/nnfabrik/main.py
+++ b/nnfabrik/main.py
@@ -367,6 +367,26 @@ def custom_nnfabrik(
     is set to True, the new tables will depend on the common Fabrikant table. 
     Otherwise, a separate copy of Fabrikant table will also be prepared.
 
+    Examples:
+        Use of this function should replace any existing use of `nnfabrik` tables done via modifying the 
+        `nnfabrik.schema_name` property in `dj.config`. 
+        
+        As an example, if you previously had a code like this:
+        >>> dj.config['nfabrik.schema_name'] = 'my_schema'
+        >>> from nnfabrik import main # importing nnfabrik tables
+
+        do this instead:
+        >>> from nnfabrik.main import custom_nnfabrik
+        >>> main = custom_nnfabrik('my_schema')    # this has the same effect as defining nnfabrik tables in schema `my_schema`
+
+        Also, you can achieve the equivalent of:
+        >>> dj.config['nfabrik.schema_name'] = 'my_schema'
+        >>> from nnfabrik.main import *
+
+        by doing
+        >>> from nnfabrik.main import custom_nnfabrik
+        >>> custom_nnfabrik('my_schema', context=locals())
+
     Args:
         schema (str or dj.Schema): Name of schema or dj.Schema object
         use_common_fabrikant (bool, optional): If True, new tables will depend on the
@@ -381,6 +401,10 @@ def custom_nnfabrik(
             instead the tables are defined inside the context.
         spawn_existing_tables (bool, optional): If True, perform `spawn_missing_tables` operation
             onto the newly created table. Defaults to False.
+
+    Raises:
+        ValueError: If `use_common_fabrikant` is True but the target `schema` already contains its own
+            copy of `Fabrikant` table.
 
     Returns:
         Python Module object or None: If `context` was None, a new Python module containing 
@@ -410,9 +434,7 @@ def custom_nnfabrik(
 
     if use_common_fabrikant:
         if "Fabrikant" in temp_context:
-            warnings.warn(
-                "The schema already contained Fabrikant table. Using that table instead of the common one!"
-            )
+            raise ValueError("The schema already contains a Fabrikant table despite setting use_common_fabrikant=True. Either rerun with use_common_fabrikant=False or remove the Fabrikant table in the schema")
         else:
             context["Fabrikant"] = Fabrikant
             # skip creating Fabrikant table

--- a/nnfabrik/main.py
+++ b/nnfabrik/main.py
@@ -353,7 +353,7 @@ class Seed(dj.Manual):
     """
 
 
-def custom_nnfabrik(
+def mein_nnfabrik(
     schema,
     use_common_fabrikant=True,
     use_common_seed=False,
@@ -376,16 +376,16 @@ def custom_nnfabrik(
         >>> from nnfabrik import main # importing nnfabrik tables
 
         do this instead:
-        >>> from nnfabrik.main import custom_nnfabrik
-        >>> main = custom_nnfabrik('my_schema')    # this has the same effect as defining nnfabrik tables in schema `my_schema`
+        >>> from nnfabrik.main import mein_nnfabrik
+        >>> main = mein_nnfabrik('my_schema')    # this has the same effect as defining nnfabrik tables in schema `my_schema`
 
         Also, you can achieve the equivalent of:
         >>> dj.config['nfabrik.schema_name'] = 'my_schema'
         >>> from nnfabrik.main import *
 
         by doing
-        >>> from nnfabrik.main import custom_nnfabrik
-        >>> custom_nnfabrik('my_schema', context=locals())
+        >>> from nnfabrik.main import mein_nnfabrik
+        >>> mein_nnfabrik('my_schema', context=locals())
 
     Args:
         schema (str or dj.Schema): Name of schema or dj.Schema object

--- a/nnfabrik/templates/utility.py
+++ b/nnfabrik/templates/utility.py
@@ -6,8 +6,8 @@ from nnfabrik.builder import resolve_data
 class DataInfoBase(dj.Computed):
     """
     Inherit from this class and decorate with your own schema to create a functional
-    DataInfo table. By default, this will inherit from the Dataset as found in nnfabrik.main.
-    To change this behavior, overwrite the dataset_table` property.
+    DataInfo table. By default, this will depend on Dataset table as found in nnfabrik.main.
+    To change this behavior, overwrite the `dataset_table` property of this class.
     """
 
     dataset_table = Dataset
@@ -26,7 +26,9 @@ class DataInfoBase(dj.Computed):
 
             ->[nullable] self.user_table
             datainfo_ts=CURRENT_TIMESTAMP: timestamp    # UTZ timestamp at time of insertion
-            """.format(table_comment=self.table_comment)
+            """.format(
+            table_comment=self.table_comment
+        )
         return definition
 
     def make(self, key):
@@ -50,6 +52,6 @@ class DataInfoBase(dj.Computed):
 
         fabrikant_name = self.user_table.get_current_user()
 
-        key['fabrikant_name'] = fabrikant_name
-        key['data_info'] = data_info
+        key["fabrikant_name"] = fabrikant_name
+        key["data_info"] = data_info
         self.insert1(key)


### PR DESCRIPTION
Add a function `my_nnfabrik` to easily create "replica" of `Model`, `Dataset`, and `Trainer` into a schema you define. Use of this function then should replace any existing use of `nnfabrik` tables done via modifying the `nnfabrik.schema_name` property in `dj.config`. As an example, if you previously had a code like this:

```python
dj.config['nfabrik.schema_name'] = 'my_schema'
from nnfabrik import main # importing nnfabrik tables
```

Do this instead:

```python
from nnfabrik.main import my_nnfabrik
main = my_nnfabrik('my_schema')    # this has the same effect as defining nnfabrik tables in schema `my_schema`
```

One notable exception is that by default, `my_nnfabrik` will use the "core" `Fabrikant` table instead of creating one a new. If you already have an existing `Fabrikant` table in the target schema, then the existing Fabrikant table will supersede. Alternatively, you can set `use_common_fabrikant=False` when invoking `my_nnfabrik` to explicitly create your schema specific `Fabrikant` table and make other tables depend on that instead of the common one.


You can achieve the equivalent to:

```python
dj.config['nfabrik.schema_name'] = 'my_schema'
from nnfabrik.main import *
```

by doing

```python
from nnfabrik.main import my_nnfabrik
my_nnfabrik('my_schema', context=locals())
```  