### PR TITLE
Make compatible with new schema path

### DIFF
--- a/nnfabrik/main.py
+++ b/nnfabrik/main.py
@@ -4,7 +4,6 @@ from typing import Union, Optional, MutableMapping
 
 
 import datajoint as dj
-from datajoint.schema import Schema
 
 from .builder import (
     resolve_model,
@@ -14,7 +13,7 @@ from .builder import (
     get_model,
     get_trainer,
 )
-from .utility.dj_helpers import make_hash, CustomSchema
+from .utility.dj_helpers import make_hash, CustomSchema, Schema
 from .utility.nnf_helper import cleanup_numpy_scalar
 
 


### PR DESCRIPTION
DJ > 0.12.4 now has `schema` package renamed to `schemas`, fixing previously occurring name collisions. This however means we have to deal with both possibilities until we are fully migrated.

Inside `dj_helpers`, we have already had code to deal with this. I have now updated the `main.py` to get `Schema` reference from there.