### PR TITLE
Fix workflow failing if docs didn't change

### DIFF
--- a/.github/workflows/gh_pages.yml
+++ b/.github/workflows/gh_pages.yml
@@ -41,5 +41,4 @@ jobs:
           git config user.name github-actions
           git config user.email github-actions@github.com
           git add .
-          git commit -m "Add documentation"
-          git push
+          git diff --exit-code --cached || git commit -m "Add documentation" && git push


### PR DESCRIPTION
The `gh_pages` workflow currently fails if the documentation didn't change from the last time the workflow ran because it is trying to commit nothing. This PR adds a check to the workflow such that it only commits changes if there are any.