### PR TITLE
Fix black workflow failing due to import error

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -10,4 +10,4 @@ jobs:
     - uses: actions/setup-python@v2
     - uses: psf/black@stable
       with:
-        version: "22.1.0"
+        version: "22.3.0"


### PR DESCRIPTION
The workflow was failing due to an imcompatibility with click 8.1.0.
Using a newer version of black fixes this issue.
