### PR TITLE
Adds possibility to use `log_scale` argument in Random hyperparameter search

### DIFF
--- a/nnfabrik/utility/hypersearch.py
+++ b/nnfabrik/utility/hypersearch.py
@@ -1,4 +1,5 @@
 import numpy as np
+from scipy.stats import loguniform
 from ax.service.managed_loop import optimize
 from .nnf_helper import split_module_name, dynamic_import
 from nnfabrik.main import *
@@ -471,7 +472,10 @@ class Random:
             elif param["type"] == "choice":
                 auto_params_val.update({param["name"]: np.random.choice(param["values"])})
             elif param["type"] == "range":
-                auto_params_val.update({param["name"]: np.random.uniform(*param["bounds"])})
+                if "log_scale" in param and param["log_scale"]:
+                    auto_params_val.update({param["name"]: loguniform.rvs(*param["bounds"])})
+                else:
+                    auto_params_val.update({param["name"]: np.random.uniform(*param["bounds"])})
 
         return auto_params_val
 


### PR DESCRIPTION
So far, setting the `"log_scale": True` was ignored in the `Random` hyper search, e.g. 

```python
model_config_auto = dict(
    input_smoothness={"type": "range", "bounds": [4e2, 1e6], "log_scale": True}
)
```
performed search using sampling from the uniform instead of loguniform distribution.