### PR TITLE
Adds option to include seed into random search

### DIFF
--- a/nnfabrik/utility/hypersearch.py
+++ b/nnfabrik/utility/hypersearch.py
@@ -266,6 +266,8 @@ class Random:
         trainer_fn (str): name of the trainer function
         trainer_config (dict): dictionary of arguments for trainer function that are fixed
         trainer_config_auto (dict): dictionary of arguments for trainer function that are to be randomly sampled
+        seed_config_auto (dict): dictionary of arguments for setting (`dict(seed={"type": "fixed", "value": <VALUE>})`)
+            or random sampling (`dict(seed={"type": "int"})`) the seed
         architect (str): Name of the contributor that added this entry
         trained_model_table (str): name (importable) of the trained_model_table
         total_trials (int, optional): Number of experiments (i.e. training) to run. Defaults to 5.
@@ -499,7 +501,5 @@ class Random:
         """
         Runs the random hyperparameter search, for as many trials as specified.
         """
-        # n_trials = len(self.trained_model_table().seed_table()) * self.total_trials
-        # init_len = len(self.trained_model_table())
         for _ in range(self.total_trials):
             self.train_evaluate(self.gen_params_value())


### PR DESCRIPTION
So far, hyper random search was done for the seeds in the Seed table. However, you can get even better models by trying (i.e. randomly sampling) different weight initializations. To do that, the according seed has to be randomly sampled, too. This PR adds this feature. Setting and passing

```python
seed_config_auto = dict(seed={"type": "int"})


# %%
optim_results = Random(
    dataset_fn,
    dataset_config,
    dataset_config_auto,
    model_fn,
    model_config,
    model_config_auto,
    trainer_fn,
    trainer_config,
    trainer_config_auto,
    seed_config_auto,
    "mburg",
    "controversialstimuli.tables.trained_model.TrainedModelHPSearchRandom",
    total_trials=100,
    comment="Random optimization of Hyper params.",
)
```

randomly samples an int32 value for the seed, adds it to the Seed table, and then performs model training, with the same logic as the random search did before. 

To use a fixed seed: `seed_config_auto = dict(seed={"type": "fixed", "value": <VALUE>})`.

Note that the meaning of the `total_trials` argument now is slightly different: For each Random.run(...) there will be `total_trials` numbers of parameters sampled and models fitted, irrespective of how many entries the Seed and Random.trained_model_table have. From my perspective, this is actually intended behavior, but maybe something to discuss in code review - what do you think @mohammadbashiri ?